### PR TITLE
Remove no need max item restriction for data source curation

### DIFF
--- a/typesense/data_source_curation.go
+++ b/typesense/data_source_curation.go
@@ -22,7 +22,6 @@ func dataSourceTypesenseCuration() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: "Rule of this curation",
 				Computed:    true,
-				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"query": {


### PR DESCRIPTION
## WHAT

As title.

## WHY

Because it can't be configured for data source computed fields.
