### PR TITLE
Update document implementation

### DIFF
--- a/docs/data-sources/document.md
+++ b/docs/data-sources/document.md
@@ -25,7 +25,10 @@ data "typesense_document" "my_doc" {
 ### Required
 
 - **collection_name** (String) Name of the collection
-- **id** (String) ID of the document
+
+### Optional
+
+- **id** (String) The ID of this resource.
 
 ### Read-Only
 

--- a/docs/resources/document.md
+++ b/docs/resources/document.md
@@ -32,7 +32,10 @@ resource "typesense_document" "doc" {
 
 - **collection_name** (String) Name of the collection
 - **document** (Map of String) Document's body
-- **id** (String) ID of the document
+
+### Optional
+
+- **id** (String) The ID of this resource.
 
 ## Import
 

--- a/typesense/data_source_document.go
+++ b/typesense/data_source_document.go
@@ -8,11 +8,6 @@ func dataSourceTypesenseDocument() *schema.Resource {
 	return &schema.Resource{
 		Description: "Item in a collection",
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:        schema.TypeString,
-				Description: "ID of the document",
-				Required:    true,
-			},
 			"collection_name": {
 				Type:        schema.TypeString,
 				Description: "Name of the collection",

--- a/typesense/resource_document.go
+++ b/typesense/resource_document.go
@@ -13,11 +13,6 @@ func resourceTypesenseDocument() *schema.Resource {
 	return &schema.Resource{
 		Description: "Item in a collection",
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:        schema.TypeString,
-				Description: "ID of the document",
-				Required:    true,
-			},
 			"collection_name": {
 				Type:        schema.TypeString,
 				Description: "Name of the collection",
@@ -61,11 +56,11 @@ func resourceTypesenseDocumentUpsert(ctx context.Context, d *schema.ResourceData
 	}
 
 	var id string
-	if v, ok := d.GetOk("id"); ok {
+	if v, ok := document["id"]; ok {
 		id = v.(string)
+	} else {
+		return diag.Errorf("id required for document")
 	}
-
-	document["id"] = id
 
 	_, err := client.Collection(collectionName).Documents().Create(document)
 	if err != nil {


### PR DESCRIPTION
## WHAT

Remove `id` argument.

## WHY

Because `id` is reserved by Terrafrom.
