### PR TITLE
Add missing forcenew

### DIFF
--- a/examples/resources/typesense_collection_alias/import.sh
+++ b/examples/resources/typesense_collection_alias/import.sh
@@ -1,1 +1,1 @@
-terraform import typesense_collection_alias.my_alias my_collection.my-alias
+terraform import typesense_collection_alias.my_alias my-alias

--- a/typesense/resource_collection_alias.go
+++ b/typesense/resource_collection_alias.go
@@ -17,6 +17,7 @@ func resourceTypesenseCollectionAlias() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Name of the collection alias",
 				Required:    true,
+				ForceNew:    true,
 			},
 			"collection_name": {
 				Type:        schema.TypeString,

--- a/typesense/resource_curation.go
+++ b/typesense/resource_curation.go
@@ -19,6 +19,7 @@ func resourceTypesenseCuration() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Name of the curation",
 				Required:    true,
+				ForceNew:    true,
 			},
 			"collection_name": {
 				Type:        schema.TypeString,

--- a/typesense/resource_curation.go
+++ b/typesense/resource_curation.go
@@ -170,6 +170,10 @@ func resourceTypesenseCurationRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
+	if err := d.Set("collection_name", collectionName); err != nil {
+		return diag.FromErr(err)
+	}
+
 	if err := d.Set("rule", flattenCurationRule(override.Rule)); err != nil {
 		return diag.FromErr(err)
 	}

--- a/typesense/resource_document.go
+++ b/typesense/resource_document.go
@@ -91,6 +91,10 @@ func resourceTypesenseDocumentRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
+	if err := d.Set("collection_name", collectionName); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return diags
 }
 

--- a/typesense/resource_document.go
+++ b/typesense/resource_document.go
@@ -21,6 +21,7 @@ func resourceTypesenseDocument() *schema.Resource {
 			"document": {
 				Type:        schema.TypeMap,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Document's body",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/typesense/resource_synonyms.go
+++ b/typesense/resource_synonyms.go
@@ -89,6 +89,10 @@ func resourceTypesenseSynonymsRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
+	if err := d.Set("collection_name", collectionName); err != nil {
+		return diag.FromErr(err)
+	}
+
 	if err := d.Set("name", synonym.Id); err != nil {
 		return diag.FromErr(err)
 	}

--- a/typesense/resource_synonyms.go
+++ b/typesense/resource_synonyms.go
@@ -18,6 +18,7 @@ func resourceTypesenseSynonyms() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Name of the synonyms",
 				Required:    true,
+				ForceNew:    true,
 			},
 			"collection_name": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
## WHAT

As title.

## WHY

Because the API only supports `upsert` and needs to force destroy on `name` updates.
